### PR TITLE
changed ivyLocal to use environment variable

### DIFF
--- a/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
+++ b/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
@@ -40,8 +40,8 @@ trait ScalablyTyped extends ScalaJSModule with VersionSpecific {
 
   private def scalablyTypedImportTask = T {
     packageJsonSource()
-    val ivyLocal = sys.props
-      .get("ivy.home")
+    val ivyLocal = sys.env
+      .get("IVY_HOME")
       .map(os.Path(_))
       .getOrElse(os.home / ".ivy2") / "local"
 


### PR DESCRIPTION
it is more likely users have set IVY_HOME if they have a .ivy2/ directory that is not the default ~/.ivy2. Properties are not always passed and forkArgs runs well after scalablytyped conversions.