### PR TITLE
Update scalablyTypedImportTask to also check for IVY_HOME

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 out
 node_modules
 .bsp
+.bloop
+.metals

--- a/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
+++ b/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
@@ -44,6 +44,7 @@ trait ScalablyTyped extends ScalaJSModule with VersionSpecific {
       .get("ivy.home")
       .map(os.Path(_))
       .getOrElse(sys.env.get("IVY_HOME")
+                 .map(os.Path(_))
                  .getOrElse(os.home / ".ivy2")) / "local"
 
     val targetPath = T.dest / "out"

--- a/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
+++ b/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
@@ -41,11 +41,9 @@ trait ScalablyTyped extends ScalaJSModule with VersionSpecific {
   private def scalablyTypedImportTask = T {
     packageJsonSource()
     val ivyLocal = sys.props
-      .get("ivy.home")
-      .map(os.Path(_))
-      .getOrElse(sys.env.get("IVY_HOME")
-                 .map(os.Path(_))
-                 .getOrElse(os.home / ".ivy2")) / "local"
+      .get("ivy.home").map(os.Path(_))
+        .getOrElse(sys.env.get("IVY_HOME").map(os.Path(_))
+          .getOrElse(os.home / ".ivy2")) / "local"
 
     val targetPath = T.dest / "out"
 

--- a/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
+++ b/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
@@ -43,7 +43,8 @@ trait ScalablyTyped extends ScalaJSModule with VersionSpecific {
     val ivyLocal = sys.props
       .get("ivy.home")
       .map(os.Path(_))
-      .getOrElse(os.home / ".ivy2") / "local"
+      .getOrElse(sys.env.get("IVY_HOME")
+                 .getOrElse(os.home / ".ivy2")) / "local"
 
     val targetPath = T.dest / "out"
 


### PR DESCRIPTION
This enables the Task to also look for IVY_HOME if the user has specified it. If not, it still defaults to `~/.ivy2`. It still looks for any Java declaration flags `-Divy.home=<...>` if passed in first.

This was first opened by #35 and adds the suggestion for making this change additive rather than replacing the original sys.props check. Deleted the other one, because I was using github.com to make the edits, rather than on my machine.