### PR TITLE
Add `scalablyTypedOutputPackage` target

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Can be one of `Flavour.Normal`, `Flavour.Slinky`, `Flavour.SlinkyNative` and `Fl
 
 If `true` generate facades for dev dependencies as well. Default: `false`
 
-### outputPackage
+### scalablyTypedOutputPackage
 
 Adjusts the top-level package name of the generated code.
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Can be one of `Flavour.Normal`, `Flavour.Slinky`, `Flavour.SlinkyNative` and `Fl
 
 If `true` generate facades for dev dependencies as well. Default: `false`
 
+### outputPackage
+
+Adjusts the top-level package name of the generated code.
+
 ## Changelog
 
 ### 0.1.15

--- a/mill-scalablytyped-worker-api/src/com/github/lolgab/mill/scalablytyped/worker/api/ScalablyTypedWorkerApi.java
+++ b/mill-scalablytyped-worker-api/src/com/github/lolgab/mill/scalablytyped/worker/api/ScalablyTypedWorkerApi.java
@@ -6,4 +6,6 @@ public interface ScalablyTypedWorkerApi {
 	ScalablyTypedWorkerDep[] scalablytypedImport(Path basePath, Path ivyHomePath, Path targetPath, String scalaVersion,
 			String scalaJSVersion, String[] ignoredLibs, boolean useScalaJsDomTypes, boolean includeDev,
 			ScalablyTypedWorkerFlavour flavour, String outputPackage);
+
+	String defaultOutputPackage();
 }

--- a/mill-scalablytyped-worker-api/src/com/github/lolgab/mill/scalablytyped/worker/api/ScalablyTypedWorkerApi.java
+++ b/mill-scalablytyped-worker-api/src/com/github/lolgab/mill/scalablytyped/worker/api/ScalablyTypedWorkerApi.java
@@ -5,5 +5,5 @@ import java.nio.file.Path;
 public interface ScalablyTypedWorkerApi {
 	ScalablyTypedWorkerDep[] scalablytypedImport(Path basePath, Path ivyHomePath, Path targetPath, String scalaVersion,
 			String scalaJSVersion, String[] ignoredLibs, boolean useScalaJsDomTypes, boolean includeDev,
-			ScalablyTypedWorkerFlavour flavour);
+			ScalablyTypedWorkerFlavour flavour, String outputPackage);
 }

--- a/mill-scalablytyped-worker/src/com/github/lolgab/mill/scalablytyped/worker/ScalablyTypedWorkerImpl.scala
+++ b/mill-scalablytyped-worker/src/com/github/lolgab/mill/scalablytyped/worker/ScalablyTypedWorkerImpl.scala
@@ -67,12 +67,16 @@ class ScalablyTypedWorkerImpl extends ScalablyTypedWorkerApi {
       ignoredLibs: Array[String],
       useScalaJsDomTypes: Boolean,
       includeDev: Boolean,
-      flavour: ScalablyTypedWorkerFlavour
+      flavour: ScalablyTypedWorkerFlavour,
+      outputPackage: String
   ): Array[ScalablyTypedWorkerDep] = {
 
     val DefaultOptions = ConversionOptions(
       useScalaJsDomTypes = useScalaJsDomTypes,
-      outputPackage = Name.typings,
+      outputPackage = Some(outputPackage)
+        .filter(_.nonEmpty)
+        .map(Name(_))
+        .getOrElse(Name.typings),
       enableScalaJsDefined = Selection.All,
       flavour = toScalablyTyped(flavour),
       ignored = SortedSet("typescript") ++ ignoredLibs,

--- a/mill-scalablytyped-worker/src/com/github/lolgab/mill/scalablytyped/worker/ScalablyTypedWorkerImpl.scala
+++ b/mill-scalablytyped-worker/src/com/github/lolgab/mill/scalablytyped/worker/ScalablyTypedWorkerImpl.scala
@@ -73,10 +73,8 @@ class ScalablyTypedWorkerImpl extends ScalablyTypedWorkerApi {
 
     val DefaultOptions = ConversionOptions(
       useScalaJsDomTypes = useScalaJsDomTypes,
-      outputPackage = Some(outputPackage)
-        .filter(_.nonEmpty)
-        .map(Name(_))
-        .getOrElse(Name.typings),
+      outputPackage =
+        if (outputPackage.isEmpty) Name.typings else Name(outputPackage),
       enableScalaJsDefined = Selection.All,
       flavour = toScalablyTyped(flavour),
       ignored = SortedSet("typescript") ++ ignoredLibs,

--- a/mill-scalablytyped-worker/src/com/github/lolgab/mill/scalablytyped/worker/ScalablyTypedWorkerImpl.scala
+++ b/mill-scalablytyped-worker/src/com/github/lolgab/mill/scalablytyped/worker/ScalablyTypedWorkerImpl.scala
@@ -73,8 +73,7 @@ class ScalablyTypedWorkerImpl extends ScalablyTypedWorkerApi {
 
     val DefaultOptions = ConversionOptions(
       useScalaJsDomTypes = useScalaJsDomTypes,
-      outputPackage =
-        if (outputPackage.isEmpty) Name.typings else Name(outputPackage),
+      outputPackage = Name(outputPackage),
       enableScalaJsDefined = Selection.All,
       flavour = toScalablyTyped(flavour),
       ignored = SortedSet("typescript") ++ ignoredLibs,
@@ -337,4 +336,6 @@ class ScalablyTypedWorkerImpl extends ScalablyTypedWorkerApi {
 
     }
   }
+
+  override def defaultOutputPackage(): String = Name.typings.unescaped
 }

--- a/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
+++ b/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
@@ -35,6 +35,10 @@ trait ScalablyTyped extends ScalaJSModule {
     Flavour.Normal
   }
 
+  /** The output package name.
+    */
+  def outputPackage: T[String] = Task { "" }
+
   /** Generate facades for dev dependencies as well.
     */
   def scalablyTypedIncludeDev: T[Boolean] = Task { false }
@@ -64,7 +68,8 @@ trait ScalablyTyped extends ScalaJSModule {
       scalablyTypedIgnoredLibs().toArray,
       useScalaJsDomTypes(),
       scalablyTypedIncludeDev(),
-      flavour
+      flavour,
+      outputPackage()
     )
     deps.map { dep =>
       Dep

--- a/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
+++ b/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
@@ -35,9 +35,9 @@ trait ScalablyTyped extends ScalaJSModule {
     Flavour.Normal
   }
 
-  /** The output package name.
+  /** The top-level package to put generated code in.
     */
-  def outputPackage: T[String] = Task { "" }
+  def scalablyTypedOutputPackage: T[String] = Task { "" }
 
   /** Generate facades for dev dependencies as well.
     */
@@ -69,7 +69,7 @@ trait ScalablyTyped extends ScalaJSModule {
       useScalaJsDomTypes(),
       scalablyTypedIncludeDev(),
       flavour,
-      outputPackage()
+      scalablyTypedOutputPackage()
     )
     deps.map { dep =>
       Dep

--- a/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
+++ b/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
@@ -37,7 +37,9 @@ trait ScalablyTyped extends ScalaJSModule {
 
   /** The top-level package to put generated code in.
     */
-  def scalablyTypedOutputPackage: T[String] = Task { "" }
+  def scalablyTypedOutputPackage: T[String] = Task {
+    scalablyTypedWorker().defaultOutputPackage()
+  }
 
   /** Generate facades for dev dependencies as well.
     */


### PR DESCRIPTION
While trying to migrate an sbt project which is using the [sbt plugin](https://scalablytyped.org/docs/plugin) of ScalablyTyped, I ran into some missing config options. One is this outputPackage. 
For now I just quickly added this one, perhaps later I add others. But I also have some issues with running JS tests which require the `node_modules` directory. Currently I was unable to get it available in the out-dir scopes. So for now I am not using Mill to run these JS tests and keep my Mill build in sync until I can cover all the corner cases I require. 