### PR TITLE
Make `scalablyTypedBasePath` a `Task[os.Path]` to depend on other tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ It will run ScalablyTyped to convert the libraries in `package.json` and then ad
 ### scalablyTypedBasePath
 
 The base path where package.json and node_modules are.
+When overriding you need to override also `scalablyTypedPackageJson` accordingly.
+
+### scalablyTypedPackageJson
+
+The base path where package.json and node_modules are.
 Defaults to the project root directory (the directory of `build.mill`).
+When overriding you need to override also `scalablyTypedBasePath` accordingly.
 
 ### scalablyTypedIgnoredLibs
 

--- a/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
+++ b/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
@@ -12,18 +12,19 @@ trait ScalablyTyped extends ScalaJSModule {
     ScalablyTypedWorkerApi.scalablyTypedWorker().impl(classpath)
   }
 
-  private def packageJsonSource = Task.Anon {
-    Task.Source {
-      scalablyTypedBasePathTask() / "package.json"
-      // Task.workspace / "package.json"
-    }
+  /** The path of package.json. When overriding you need to override also
+    * `scalablyTypedBasePath` accordingly.
+    */
+  def scalablyTypedPackageJson: T[PathRef] = Task.Source {
+    mill.api.BuildCtx.workspaceRoot / "package.json"
   }
 
-  /** The base path where package.json and node_modules are.
+  /** The base path where package.json and node_modules are. When overriding you
+    * need to override also `scalablyTypedPackageJson` accordingly.
     */
-  def scalablyTypedBasePath: os.Path = mill.api.BuildCtx.workspaceRoot
-
-  def scalablyTypedBasePathTask: T[os.Path] = Task.Input { scalablyTypedBasePath }
+  def scalablyTypedBasePath: T[os.Path] = Task {
+    mill.api.BuildCtx.workspaceRoot
+  }
 
   /** The TypeScript dependencies to ignore during the conversion
     */
@@ -51,7 +52,7 @@ trait ScalablyTyped extends ScalaJSModule {
   def scalablyTypedIncludeDev: T[Boolean] = Task { false }
 
   private def scalablyTypedImportTask = Task {
-    packageJsonSource()
+    scalablyTypedPackageJson()
     val ivyLocal = sys.props
       .get("ivy.home")
       .map(os.Path(_))
@@ -66,7 +67,7 @@ trait ScalablyTyped extends ScalaJSModule {
       case Flavour.ScalajsReact => ScalablyTypedWorkerFlavour.ScalajsReact
     }
 
-    val basePath = scalablyTypedBasePathTask()
+    val basePath = scalablyTypedBasePath()
 
     val deps =
       scalablyTypedWorker().scalablytypedImport(

--- a/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
+++ b/mill-scalablytyped/src/com/github/lolgab/mill/scalablytyped/ScalablyTyped.scala
@@ -14,16 +14,16 @@ trait ScalablyTyped extends ScalaJSModule {
 
   private def packageJsonSource = Task.Anon {
     Task.Source {
-      scalablyTypedBasePath() / "package.json"
+      scalablyTypedBasePathTask() / "package.json"
       // Task.workspace / "package.json"
     }
   }
 
   /** The base path where package.json and node_modules are.
     */
-  def scalablyTypedBasePath: T[os.Path] = Task {
-    os.Path(sys.env("MILL_WORKSPACE_ROOT"))
-  }
+  def scalablyTypedBasePath: os.Path = mill.api.BuildCtx.workspaceRoot
+
+  def scalablyTypedBasePathTask: T[os.Path] = Task.Input { scalablyTypedBasePath }
 
   /** The TypeScript dependencies to ignore during the conversion
     */
@@ -66,7 +66,7 @@ trait ScalablyTyped extends ScalaJSModule {
       case Flavour.ScalajsReact => ScalablyTypedWorkerFlavour.ScalajsReact
     }
 
-    val basePath = scalablyTypedBasePath()
+    val basePath = scalablyTypedBasePathTask()
 
     val deps =
       scalablyTypedWorker().scalablytypedImport(


### PR DESCRIPTION
breaking: this will require a small migration for existing usage of scalablyTypedBasePath

I made this breaking change so I can use mill-bundler to generate the package.json, then consume it with mill-scalablytyped and smoothen test-setups with its RollupModule and WebpackModule.